### PR TITLE
Fully annotate unsafe code paths

### DIFF
--- a/src/common/lambda.rs
+++ b/src/common/lambda.rs
@@ -27,6 +27,7 @@ pub struct Lambda {
     /// Number of variables declared in this scope.
     pub decls: usize,
     /// Each byte is an opcode or a number-stream.
+    /// Guaranteed to be valid bytecode
     pub code: Vec<u8>,
     /// Each usize indexes the bytecode op that begins each line.
     pub spans: Vec<(usize, Span)>,
@@ -54,12 +55,12 @@ impl Lambda {
     }
 
     /// Emits an opcode as a byte.
-    pub fn emit(&mut self, op: Opcode) {
+    pub unsafe fn emit(&mut self, op: Opcode) {
         self.code.push(op as u8)
     }
 
     /// Emits a series of bytes.
-    pub fn emit_bytes(&mut self, bytes: &mut Vec<u8>) {
+    pub unsafe fn emit_bytes(&mut self, bytes: &mut Vec<u8>) {
         self.code.append(bytes)
     }
 
@@ -71,7 +72,7 @@ impl Lambda {
     }
 
     /// Removes the last emitted byte.
-    pub fn demit(&mut self) {
+    pub unsafe fn demit(&mut self) {
         self.code.pop();
     }
 
@@ -139,7 +140,7 @@ impl fmt::Display for Lambda {
 
         while index < self.code.len() {
             index += 1;
-            match Opcode::from_byte(self.code[index - 1]) {
+            match unsafe { Opcode::from_byte(self.code[index - 1]) } {
                 Opcode::Con => {
                     let (constant_index, consumed) = build_number(&self.code[index..]);
                     index += consumed;

--- a/src/common/opcode.rs
+++ b/src/common/opcode.rs
@@ -51,7 +51,7 @@ impl Opcode {
     /// This *should* never cause a crash
     /// and if it does, the vm's designed to crash hard
     /// so it'll be pretty obvious.
-    pub fn from_byte(byte: u8) -> Opcode {
-        unsafe { std::mem::transmute(byte) }
+    pub unsafe fn from_byte(byte: u8) -> Opcode {
+        std::mem::transmute(byte)
     }
 }


### PR DESCRIPTION
I've avoided making any changes to the code yet, just documenting the assumptions we're using and making the appropriate functions `unsafe`.

The amount of unsafe code present is a bit scary. I'm definitely not sure it's totally bug free, but it seems fine.

These changes highlight a few steps that can be taken to narrow the scope of the `unsafe` code here:

- Introduce functions to handle 'opcode variants' - currently we only really have opcodes with 0 or 1 arguments
- Share code for deserializing the instructions: `Display for Lambda` and `VM::step` solve similar problems
- Introduce a lexing step for the bytecode
  - An iterator will make this zero cost