### PR TITLE
Skip formatting match statements that are aligned for readability

### DIFF
--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -67,6 +67,7 @@ impl Eq for Data {}
 impl Display for Data {
     /// Displays some Passerine Data in a pretty manner, as if it were printed to console.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        #[rustfmt::skip]
         match self {
             Data::Heaped(_)   => unreachable!("Can not display heaped data"),
             Data::NotInit     => unreachable!("found uninitialized data on top of stack"),
@@ -94,6 +95,7 @@ impl Debug for Data {
     /// Displays some Passerine Data following Rust conventions,
     /// with certain fields omitted.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        #[rustfmt::skip]
         match self {
             Data::Heaped(h)   => write!(f, "Heaped({:?})", h.borrow()),
             Data::NotInit     => write!(f, "NotInit"),

--- a/src/common/span.rs
+++ b/src/common/span.rs
@@ -89,6 +89,7 @@ impl Span {
 
     /// Combines a set of `Span`s (think fold-left over `Span::combine`).
     pub fn join(mut spans: Vec<Span>) -> Span {
+        #[rustfmt::skip]
         let mut combined = match spans.pop() {
             Some(span) => span,
             None       => return Span::empty(),
@@ -170,10 +171,12 @@ impl Display for Span {
         let full_source = &self.source.as_ref().unwrap().contents;
         let lines = Span::lines(full_source);
 
+        #[rustfmt::skip]
         let (start_line, start_col) = match Span::line_index(full_source, self.offset) {
             Some(li) => li,
             None     => unreachable!(),
         };
+        #[rustfmt::skip]
         let (end_line, _end_col) = match Span::line_index(full_source, self.end()) {
             Some(li) => li,
             None     => unreachable!(),

--- a/src/compiler/cst.rs
+++ b/src/compiler/cst.rs
@@ -30,6 +30,7 @@ impl TryFrom<ASTPattern> for CSTPattern {
     /// This function may become a bit more complex once 'where' is added.
     fn try_from(ast_pattern: ASTPattern) -> Result<Self, Self::Error> {
         Ok(
+            #[rustfmt::skip]
             match ast_pattern {
                 ASTPattern::Symbol(s)   => CSTPattern::Symbol(s),
                 ASTPattern::Data(d)     => CSTPattern::Data(d),

--- a/src/compiler/hoist.rs
+++ b/src/compiler/hoist.rs
@@ -106,6 +106,7 @@ impl Hoister {
     /// This is fairly standard - hoisting happens in
     /// `self.assign`, `self.lambda`, and `self.symbol`.
     pub fn walk(&mut self, cst: Spanned<CST>) -> Result<Spanned<SST>, Syntax> {
+        #[rustfmt::skip]
         let sst: SST = match cst.item {
             CST::Data(data) => SST::Data(data),
             CST::Symbol(name) => self.symbol(&name),
@@ -124,6 +125,7 @@ impl Hoister {
     /// Walks a pattern. If `declare` is true, we shadow variables in existing scopes
     /// and creates a new variable in the local scope.
     pub fn walk_pattern(&mut self, pattern: Spanned<CSTPattern>, declare: bool) -> Spanned<SSTPattern> {
+        #[rustfmt::skip]
         let item = match pattern.item {
             CSTPattern::Symbol(name) => {
                 SSTPattern::Symbol(self.resolve_assign(&name, declare))

--- a/src/compiler/lex.rs
+++ b/src/compiler/lex.rs
@@ -133,6 +133,7 @@ impl Lexer {
         // check longest
         for rule in &rules {
             if let Ok((k, c)) = rule(source) {
+                #[rustfmt::skip]
                 match best {
                     Err(_)              => best = Ok((k, c)),
                     Ok((_, o)) if c > o => best = Ok((k, c)),
@@ -173,6 +174,7 @@ impl Lexer {
             return Err("Unexpected EOF while lexing".to_string());
         }
 
+        #[rustfmt::skip]
         match &source.as_bytes()[..literal.len()] {
             s if s == literal.as_bytes() => Ok(literal.len()),
             _                            => Err(format!("Expected '{}'", source)),

--- a/src/compiler/parse.rs
+++ b/src/compiler/parse.rs
@@ -147,6 +147,7 @@ impl Parser {
 
     /// Looks at the current token and parses an infix expression
     pub fn rule_prefix(&mut self) -> Result<Spanned<AST>, Syntax> {
+        #[rustfmt::skip]
         match self.skip().item {
             Token::End         => Ok(Spanned::new(AST::Block(vec![]), Span::empty())),
 
@@ -171,6 +172,7 @@ impl Parser {
 
     /// Looks at the current token and parses the right side of any infix expressions.
     pub fn rule_infix(&mut self, left: Spanned<AST>) -> Result<Spanned<AST>, Syntax> {
+        #[rustfmt::skip]
         match self.skip().item {
             Token::Assign  => self.assign(left),
             Token::Lambda  => self.lambda(left),
@@ -198,6 +200,7 @@ impl Parser {
         let current = self.current().item.clone();
         let sep = next != current;
 
+        #[rustfmt::skip]
         let prec = match next {
             // infix
             Token::Assign  => Prec::Assign,
@@ -305,6 +308,7 @@ impl Parser {
     pub fn literal(&mut self) -> Result<Spanned<AST>, Syntax> {
         let Spanned { item: token, span } = self.advance();
 
+        #[rustfmt::skip]
         let leaf = match token {
             Token::Unit       => AST::Data(Data::Unit),
             Token::Number(n)  => AST::Data(n.clone()),

--- a/src/compiler/rule.rs
+++ b/src/compiler/rule.rs
@@ -76,6 +76,7 @@ impl Rule {
         );
 
         for (n, t) in new {
+            #[rustfmt::skip]
             match base.entry(n) {
                 Entry::Vacant(e)   => e.insert(t),
                 Entry::Occupied(_) => return Err(collision),
@@ -179,6 +180,7 @@ impl Rule {
         bindings: &mut Bindings,
     ) -> Result<Spanned<ASTPattern>, Syntax> {
         Ok(
+            #[rustfmt::skip]
             match pattern.item {
                 ASTPattern::Symbol(name) => {
                     let span = pattern.span.clone();

--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -52,6 +52,7 @@ impl Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // pretty formatting for tokens
         // just use debug if you're not printing a message or something.
+        #[rustfmt::skip]
         let message = match self {
             Token::OpenBracket  => "an opening bracket",
             Token::CloseBracket => "a closing bracket",

--- a/src/core/logic.rs
+++ b/src/core/logic.rs
@@ -14,6 +14,7 @@ pub fn equal(data: Data) -> Result<Data, String> {
 
 pub fn greater(data: Data) -> Result<Data, String> {
     // TODO: type coercion
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(left),    Data::Real(right))    => left > right,
         (Data::Integer(left), Data::Integer(right)) => left > right,
@@ -25,6 +26,7 @@ pub fn greater(data: Data) -> Result<Data, String> {
 
 pub fn less(data: Data) -> Result<Data, String> {
     // TODO: type coercion
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(left),    Data::Real(right))    => left < right,
         (Data::Integer(left), Data::Integer(right)) => left < right,
@@ -36,6 +38,7 @@ pub fn less(data: Data) -> Result<Data, String> {
 
 pub fn greater_equal(data: Data) -> Result<Data, String> {
     // TODO: type coercion
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(left),    Data::Real(right))    => left >= right,
         (Data::Integer(left), Data::Integer(right)) => left >= right,
@@ -47,6 +50,7 @@ pub fn greater_equal(data: Data) -> Result<Data, String> {
 
 pub fn less_equal(data: Data) -> Result<Data, String> {
     // TODO: type coercion
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(left),    Data::Real(right))    => left <= right,
         (Data::Integer(left), Data::Integer(right)) => left <= right,

--- a/src/core/math.rs
+++ b/src/core/math.rs
@@ -3,6 +3,7 @@ use crate::core::extract::binop;
 
 /// Adds two numbers, concatenates two strings.
 pub fn add(data: Data) -> Result<Data, String> {
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(l),    Data::Real(r))    => Data::Real(l + r),
         (Data::Integer(l), Data::Integer(r)) => Data::Integer(l + r),
@@ -15,6 +16,7 @@ pub fn add(data: Data) -> Result<Data, String> {
 
 /// Subtraction between two numbers.
 pub fn sub(data: Data) -> Result<Data, String> {
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(l),    Data::Real(r))    => Data::Real(l - r),
         (Data::Integer(l), Data::Integer(r)) => Data::Integer(l - r),
@@ -26,6 +28,7 @@ pub fn sub(data: Data) -> Result<Data, String> {
 
 /// Negation of a numbers.
 pub fn neg(data: Data) -> Result<Data, String> {
+    #[rustfmt::skip]
     let result = match data {
         Data::Real(n)    => Data::Real(-n),
         Data::Integer(n) => Data::Integer(-n),
@@ -37,6 +40,7 @@ pub fn neg(data: Data) -> Result<Data, String> {
 
 /// Multiplication between two numbers.
 pub fn mul(data: Data) -> Result<Data, String> {
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(l),    Data::Real(r))    => Data::Real(l * r),
         (Data::Integer(l), Data::Integer(r)) => Data::Integer(l * r),
@@ -76,6 +80,7 @@ pub fn rem(data: Data) -> Result<Data, String> {
 
 /// Number to a power
 pub fn pow(data: Data) -> Result<Data, String> {
+    #[rustfmt::skip]
     let result = match binop(data) {
         (Data::Real(l),    Data::Real(r))    => Data::Real(l.powf(r)),
         (Data::Integer(l), Data::Integer(r)) => Data::Integer(l.pow(r as u32)),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -97,6 +97,7 @@ impl VM {
     pub fn step(&mut self) -> Result<(), Trace> {
         let opcode = Opcode::from_byte(self.peek_byte());
 
+        #[rustfmt::skip]
         match opcode {
             Opcode::Con     => self.con(),
             Opcode::NotInit => self.not_init(),

--- a/src/vm/slot.rs
+++ b/src/vm/slot.rs
@@ -39,6 +39,7 @@ impl Slot {
 
 impl Debug for Slot {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        #[rustfmt::skip]
         match self {
             Slot::Frame      => write!(f, "Frame"),
             Slot::Suspend(s) => write!(f, "Suspend({}, {})", s.closure.id, s.ip),

--- a/src/vm/tag.rs
+++ b/src/vm/tag.rs
@@ -95,6 +95,7 @@ impl Tagged {
     /// If the caller moves out of this pointer, the original [`Tagged`] must
     /// not be dropped
     fn extract(&self, dereference: impl FnOnce(*mut Slot) -> Slot) -> Slot {
+        #[rustfmt::skip]
         match self.0 {
             n if (n & QNAN) != QNAN     => Slot::Data(Data::Real(f64::from_bits(n))),
             u if u == (QNAN | U_FLAG)   => Slot::Data(Data::Unit),
@@ -160,6 +161,7 @@ mod test {
         for n in &[positive, negative, nan, neg_inf] {
             let data    = Data::Real(*n);
             let wrapped = Tagged::new(Slot::Data(data));
+            #[rustfmt::skip]
             match wrapped.copy().data() {
                 Data::Real(f) if f.is_nan() => assert!(n.is_nan()),
                 Data::Real(f) => assert_eq!(*n, f),


### PR DESCRIPTION
Part of a move towards formatting this project with rustfmt as mentioned in #40.

I didn't add the annotation to all `match` statements, just the ones that looked like they had manual formatting that was useful. A few of these may be overkill and I might have also missed a few that should have it. They should be easy to pick up when the entire files are formatted.